### PR TITLE
chore: añadir archivo .gitignore para Angular y PHP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,51 @@
+# -------------------------
+# Node / Angular
+# -------------------------
+node_modules/
+dist/
+tmp/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Angular cache
+.angular/
+.angular/cache/
+
+# Coverage reports
+coverage/
+
+# -------------------------
+# PHP / Composer
+# -------------------------
+vendor/
+composer.lock
+
+# -------------------------
+# Logs / temp
+# -------------------------
+*.log
+*.tmp
+*.swp
+*.bak
+
+# -------------------------
+# OS
+# -------------------------
+.DS_Store
+Thumbs.db
+
+# -------------------------
+# IDE / Editor
+# -------------------------
+.vscode/
+.idea/
+*.sublime-workspace
+*.sublime-project
+
+# -------------------------
+# Environment files
+# -------------------------
+.env
+.env.local
+.env.*.local


### PR DESCRIPTION
Se añadió un archivo .gitignore adaptado al proyecto:
- Excluye dependencias de Node (node_modules/, dist/).
- Excluye dependencias de Composer (vendor/, composer.lock).
- Excluye cachés de Angular (.angular/), logs y archivos temporales.
- Evita subir configuraciones locales de IDE (.vscode/, .idea/).
- Protege archivos de entorno (.env*).

## Summary by Sourcery

Add a new .gitignore file tailored for the Angular and PHP project to prevent committing dependencies, build artifacts, caches, IDE configurations, logs, and environment files.

Build:
- Add .gitignore entries to exclude Node modules (node_modules/, dist/)
- Add .gitignore entries to exclude Composer dependencies (vendor/, composer.lock)
- Add .gitignore entries to exclude Angular cache (.angular/), logs, and temporary files
- Add .gitignore entries to exclude IDE configurations (.vscode/, .idea/)
- Add .gitignore entries to exclude environment files (.env*)